### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
-#iOS Images Extractor
+# iOS Images Extractor
 iOS Images Extractor is a Mac app to normalize , decode and extract images from iOS apps.You can download binary release from the [latest releases](https://github.com/devcxm/iOS-Images-Extractor/releases/latest). (Sorry for my bad English)
 
 ![logo](https://raw.githubusercontent.com/devcxm/iOS-Images-Extractor/master/iOSImagesExtractor/iOSImagesExtractor/Images.xcassets/AppIcon.appiconset/AppIcon-256.png)
 
-##Support Files
+## Support Files
 - `png、jpg`
 - `ipa`
 - `car(Assets.car)`
 
-##Build
+## Build
 ```
 git clone https://github.com/devcxm/iOS-Images-Extractor
 cd iOS-Images-Extractor
 git submodule update --init --recursive
 open iOSImagesExtractor.xcworkspace
 ```
-###[中文使用方法看这里](/README_zh-Hans.md)
+### [中文使用方法看这里](/README_zh-Hans.md)
 
-##Screenshot
+## Screenshot
 ![(Screenshot)](https://cloud.githubusercontent.com/assets/8568955/7927878/874f0594-0918-11e5-9fe3-452372f5affd.gif)
 
 
-##Requirements
+## Requirements
 _**OS X 10.8 or later.**_
 
-##Change Logs
+## Change Logs
 - ###v0.3.1 2016-05-15
 Add app icons and update CARExtractor.
 
 - ###v0.2.5 2015-06-02
 First release.
 
-##Credits
+## Credits
 
 - Matt Connolly [ZipArchive](https://github.com/mattconnolly/ZipArchive)
 

--- a/README_zh-Hans.md
+++ b/README_zh-Hans.md
@@ -1,14 +1,14 @@
-#中文使用说明
+# 中文使用说明
 
-##发行版本
+## 发行版本
 
-###下载地址：[百度网盘下载](http://pan.baidu.com/s/1i4T8seT)
+### 下载地址：[百度网盘下载](http://pan.baidu.com/s/1i4T8seT)
 
-##系统要求
+## 系统要求
 * 软件最低支持OS X 10.8
 * 解压Assets.car文件需要OS X 10.10或以上版本的系统
 
 
-##使用说明
-###打开软件后，拖拽`ipa`、`car文件`、`png`、`jpg`或者`整个文件夹`到软件窗口，点击`Start`按钮即可开始提取图片资源文件。
-###图片默认输出到`/User/用户名/Downloads/iOSImagesExtractor`文件夹，可直接点击`Output Dir`按钮快速跳转到输出文件夹。
+## 使用说明
+### 打开软件后，拖拽`ipa`、`car文件`、`png`、`jpg`或者`整个文件夹`到软件窗口，点击`Start`按钮即可开始提取图片资源文件。
+### 图片默认输出到`/User/用户名/Downloads/iOSImagesExtractor`文件夹，可直接点击`Output Dir`按钮快速跳转到输出文件夹。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
